### PR TITLE
Fixnum deprecated in Ruby 2.4+

### DIFF
--- a/lib/AuthenticationSDK/core/MerchantConfig.rb
+++ b/lib/AuthenticationSDK/core/MerchantConfig.rb
@@ -36,12 +36,12 @@ public
       logmessage=''
       if @enableLog.to_s.empty?
         @enableLog = true
-      elsif @enableLog.instance_of? Fixnum
+      elsif @enableLog.instance_of? Integer
         @enableLog = @enableLog.to_s
       end
       if @logSize.to_s.empty?
         @logSize = Constants::DEFAULT_LOG_SIZE
-      elsif !@logSize.instance_of? Fixnum
+      elsif !@logSize.instance_of? Integer
         @logSize=@logSize.to_i
       end
       if @logDirectory.to_s.empty? || !Dir.exist?(@logDirectory)


### PR DESCRIPTION
Running the `cybersource-rest-client-ruby` in Ruby 2.4+ causes deprecation warnings to show up in the log.  This is due to `Fixnum` [being deprecated in Ruby 2.4](https://rubyreferences.github.io/rubychanges/2.4.html#fixnum-and-bignum-are-unified-into-integer), with the recommendation to reference the `Integer` class instead.