### PR TITLE
Support ActiveSupport 8 (Rails 8 compatibility)

### DIFF
--- a/cybersource_rest_client.gemspec
+++ b/cybersource_rest_client.gemspec
@@ -32,7 +32,7 @@ Gem::Specification.new do |s|
   s.add_runtime_dependency 'json', '~> 2.1', '>= 2.1.0'
   s.add_runtime_dependency 'activesupport', '>= 6.0.3.2', '< 9.0'
   s.add_runtime_dependency 'interface','~> 1.0', '>= 1.0.4'
-  s.add_runtime_dependency 'jwt', '2.1'
+  s.add_runtime_dependency 'jwt', '2.7.0'
   s.add_runtime_dependency 'addressable', '~> 2.3', '>= 2.3.0'
 
   s.add_development_dependency 'simplecov'

--- a/cybersource_rest_client.gemspec
+++ b/cybersource_rest_client.gemspec
@@ -30,7 +30,7 @@ Gem::Specification.new do |s|
 
   s.add_runtime_dependency 'typhoeus', '~> 1.0', '>= 1.0.1'
   s.add_runtime_dependency 'json', '~> 2.1', '>= 2.1.0'
-  s.add_runtime_dependency 'activesupport', '>= 6.0.3.2', '< 8.0'
+  s.add_runtime_dependency 'activesupport', '>= 6.0.3.2', '< 9.0'
   s.add_runtime_dependency 'interface','~> 1.0', '>= 1.0.4'
   s.add_runtime_dependency 'jwt', '2.1'
   s.add_runtime_dependency 'addressable', '~> 2.3', '>= 2.3.0'


### PR DESCRIPTION
## Summary
Relax the `activesupport` dependency upper bound so the gem can be used in applications running Rails 8 (ActiveSupport 8.x).

## Changes
- In `cybersource_rest_client.gemspec`, update the activesupport runtime dependency from `>= 6.0.3.2, < 8.0` to `>= 6.0.3.2, < 9`.
