### PR TITLE
Fix JWT request-resource-path to include query string

### DIFF
--- a/lib/AuthenticationSDK/authentication/jwt/JwtToken.rb
+++ b/lib/AuthenticationSDK/authentication/jwt/JwtToken.rb
@@ -105,10 +105,10 @@ public
 
     def extractResourcePath(request_target)
       return '' if request_target.nil? || request_target.empty?
-      
-      # Split the string to remove the query params
-      parts = request_target.split('?', 2)
-      return parts[0]
+
+      # Visa UAPI requires the full path including query string in request-resource-path.
+      # The signed path must exactly match the actual request URL or the server rejects with UNAUTHORIZED_USER.
+      request_target
     end
 
     implements TokenInterface


### PR DESCRIPTION
## Problem

`extractResourcePath` strips query parameters from the request target before signing the JWT `request-resource-path` claim. This causes an `UNAUTHORIZED_USER` 401 response on any endpoint where the actual HTTP request includes query params, because the signed path no longer matches the URL the server receives.

Example: a GET to `/uw/v1/applications?status=New` signs the path as `/uw/v1/applications`, but the server validates against `/uw/v1/applications?status=New` — they don't match, so auth fails.

## Fix

Return `request_target` as-is in `extractResourcePath` so the signed path exactly matches the full request URL including query string. The Visa Acceptance Solutions JWT specification states that `request-resource-path` should be "the complete URL path for the HTTP request."

## Verified

Confirmed with the Visa UAPI underwriting sandbox (`apitest.cybersource.com`):
- Before fix: `GET /uw/v1/applications?status=New` → 401 UNAUTHORIZED_USER
- After fix: `GET /uw/v1/applications?status=New` → 200 with encrypted MLE response